### PR TITLE
Clear command

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -69,6 +69,7 @@ Tran$act takes data security seriously. It includes features to secure financial
 Import staff lists into the address book for quick access to contact information. You can also add, edit, and remove people from the address book as needed.
 
 ---
+## Usage
 
 <div markdown="block" class="alert alert-info">
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -25,6 +25,51 @@ title: User Guide
 
 ## Features
 
+Tran$act offers a range of features designed to make transaction recording and management a seamless process. These features are tailored to the needs of accountants and finance professionals in small businesses, allowing for efficient data entry and financial reporting. Here's an overview of the key features:
+
+
+**1. Adding Transactions**
+
+Tran$act allows you to add transactions with ease. Specify the transaction type, description, amount, date, and optionally, the associated person. The system validates your input data and records the transaction in the database.
+
+**2. Removing Transactions**
+
+Remove transactions from your records with ease. Simply select the transaction you wish to delete, and the system will confirm the removal before removing it from the database.
+
+**3. Viewing All Transactions**
+
+View a comprehensive list of all recorded transactions for reference. This list provides an overview of all financial activities in one place.
+
+**4. Editing Transactions**
+
+Need to make corrections or updates to transaction records? Tran$act allows you to edit transaction details, ensuring your records are accurate.
+
+**5. Restoring Deleted Transactions**
+
+Tran$act includes a feature to restore accidentally deleted transactions. Simply select a transaction from the list of deleted items to restore it to the active records.
+
+**6. Dashboard Display**
+
+Upon opening the app, you'll be greeted with a clear and concise dashboard. The dashboard displays essential financial information, including total income, total expenses, net profit for the selected period, and a breakdown of expenses by sector.
+
+**7. Access to Financial Reports**
+
+Generate financial reports with ease. Tran$act offers the capability to produce income statements, balance sheets, and cash flow statements.
+
+**8. Customizable Reports**
+
+For those who need to share data with stakeholders, Tran$act allows you to generate customizable reports. Create reports in common formats such as PDF, CSV, and Excel, tailored to your specific needs.
+
+**9. Data Security and Backup**
+
+Tran$act takes data security seriously. It includes features to secure financial data, potentially through encryption, to protect sensitive information. Additionally, automated backups can be set up to prevent data loss due to hardware issues, and you have the ability to undo actions or restore from backups when needed.
+
+**10. Address Book**
+
+Import staff lists into the address book for quick access to contact information. You can also add, edit, and remove people from the address book as needed.
+
+---
+
 <div markdown="block" class="alert alert-info">
 
 **:information_source: Notes about the command format:**

--- a/src/main/java/transact/logic/commands/ClearResultBoxCommand.java
+++ b/src/main/java/transact/logic/commands/ClearResultBoxCommand.java
@@ -1,0 +1,21 @@
+package transact.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+
+import transact.model.Model;
+import transact.ui.MainWindow.TabWindow;
+
+/**
+ * Clears the address book.
+ */
+public class ClearResultBoxCommand extends Command {
+
+    public static final String COMMAND_WORD = "clear";
+    public static final String MESSAGE_SUCCESS = "Result Box is cleared";
+
+    @Override
+    public CommandResult execute(Model model) {
+        requireNonNull(model);
+        return new CommandResult(MESSAGE_SUCCESS, TabWindow.CURRENT, false, false, true);
+    }
+}

--- a/src/main/java/transact/logic/commands/ClearStaffCommand.java
+++ b/src/main/java/transact/logic/commands/ClearStaffCommand.java
@@ -18,6 +18,6 @@ public class ClearStaffCommand extends Command {
     public CommandResult execute(Model model) {
         requireNonNull(model);
         model.setAddressBook(new AddressBook());
-        return new CommandResult(MESSAGE_SUCCESS, TabWindow.ADDRESSBOOK, false, false, true, false);
+        return new CommandResult(MESSAGE_SUCCESS, TabWindow.ADDRESSBOOK, false, false, true);
     }
 }

--- a/src/main/java/transact/logic/commands/ClearStaffCommand.java
+++ b/src/main/java/transact/logic/commands/ClearStaffCommand.java
@@ -9,15 +9,15 @@ import transact.ui.MainWindow.TabWindow;
 /**
  * Clears the address book.
  */
-public class ClearCommand extends Command {
+public class ClearStaffCommand extends Command {
 
-    public static final String COMMAND_WORD = "clear";
+    public static final String COMMAND_WORD = "clearstaff";
     public static final String MESSAGE_SUCCESS = "Address book has been cleared!";
 
     @Override
     public CommandResult execute(Model model) {
         requireNonNull(model);
         model.setAddressBook(new AddressBook());
-        return new CommandResult(MESSAGE_SUCCESS, TabWindow.ADDRESSBOOK);
+        return new CommandResult(MESSAGE_SUCCESS, TabWindow.ADDRESSBOOK, false, false, true, false);
     }
 }

--- a/src/main/java/transact/logic/commands/ClearTransactionCommand.java
+++ b/src/main/java/transact/logic/commands/ClearTransactionCommand.java
@@ -18,7 +18,7 @@ public class ClearTransactionCommand extends Command {
     public CommandResult execute(Model model) {
         requireNonNull(model);
         model.setTransactionBook(new TransactionBook());
-        return new CommandResult(MESSAGE_SUCCESS, TabWindow.TRANSACTIONS, false, false, false, true);
+        return new CommandResult(MESSAGE_SUCCESS, TabWindow.TRANSACTIONS, false, false);
     }
 }
 

--- a/src/main/java/transact/logic/commands/ClearTransactionCommand.java
+++ b/src/main/java/transact/logic/commands/ClearTransactionCommand.java
@@ -2,8 +2,8 @@ package transact.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 
-import transact.model.TransactionBook;
 import transact.model.Model;
+import transact.model.TransactionBook;
 import transact.ui.MainWindow.TabWindow;
 
 /**

--- a/src/main/java/transact/logic/commands/ClearTransactionCommand.java
+++ b/src/main/java/transact/logic/commands/ClearTransactionCommand.java
@@ -1,0 +1,24 @@
+package transact.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+
+import transact.model.TransactionBook;
+import transact.model.Model;
+import transact.ui.MainWindow.TabWindow;
+
+/**
+ * Clears the transaction list.
+ */
+public class ClearTransactionCommand extends Command {
+
+    public static final String COMMAND_WORD = "cleartransaction";
+    public static final String MESSAGE_SUCCESS = "Transaction list has been cleared!";
+
+    @Override
+    public CommandResult execute(Model model) {
+        requireNonNull(model);
+        model.setTransactionBook(new TransactionBook());
+        return new CommandResult(MESSAGE_SUCCESS, TabWindow.TRANSACTIONS, false, false, false, true);
+    }
+}
+

--- a/src/main/java/transact/logic/commands/CommandResult.java
+++ b/src/main/java/transact/logic/commands/CommandResult.java
@@ -22,6 +22,9 @@ public class CommandResult {
     /** The application should exit. */
     private final boolean exit;
 
+    private final boolean clearStaffs;
+
+    private final boolean clearTransactions;
     /**
      * Constructs a {@code CommandResult} with the specified fields.
      */
@@ -30,6 +33,19 @@ public class CommandResult {
         this.tabWindow = tabWindow;
         this.showHelp = showHelp;
         this.exit = exit;
+        this.clearStaffs = false;
+        this.clearTransactions = false;
+    }
+    /**
+     * Constructs a {@code CommandResult} with the specified fields.
+     */
+    public CommandResult(String feedbackToUser, TabWindow tabWindow, boolean showHelp, boolean exit, boolean clearStaffs, boolean clearTransactions) {
+        this.feedbackToUser = requireNonNull(feedbackToUser);
+        this.tabWindow = tabWindow;
+        this.showHelp = showHelp;
+        this.exit = exit;
+        this.clearStaffs = clearStaffs;
+        this.clearTransactions = clearTransactions;
     }
 
     /**
@@ -38,7 +54,7 @@ public class CommandResult {
      * and other fields set to their default value.
      */
     public CommandResult(String feedbackToUser, TabWindow tabWindow) {
-        this(feedbackToUser, tabWindow, false, false);
+        this(feedbackToUser, tabWindow, false, false, false, false);
     }
 
     /**
@@ -46,7 +62,7 @@ public class CommandResult {
      * and other fields set to their default value.
      */
     public CommandResult(String feedbackToUser) {
-        this(feedbackToUser, TabWindow.CURRENT, false, false);
+        this(feedbackToUser, TabWindow.CURRENT, false, false, false, false);
     }
 
     public String getFeedbackToUser() {
@@ -63,6 +79,14 @@ public class CommandResult {
 
     public boolean isExit() {
         return exit;
+    }
+
+    public boolean isClearStaffs() {
+        return clearStaffs;
+    }
+
+    public boolean isClearTransactions() {
+        return clearTransactions;
     }
 
     @Override

--- a/src/main/java/transact/logic/commands/CommandResult.java
+++ b/src/main/java/transact/logic/commands/CommandResult.java
@@ -22,9 +22,8 @@ public class CommandResult {
     /** The application should exit. */
     private final boolean exit;
 
-    private final boolean clearStaffs;
+    private final boolean clearResultDisplay;
 
-    private final boolean clearTransactions;
     /**
      * Constructs a {@code CommandResult} with the specified fields.
      */
@@ -33,19 +32,17 @@ public class CommandResult {
         this.tabWindow = tabWindow;
         this.showHelp = showHelp;
         this.exit = exit;
-        this.clearStaffs = false;
-        this.clearTransactions = false;
+        this.clearResultDisplay = false;
     }
     /**
      * Constructs a {@code CommandResult} with the specified fields.
      */
-    public CommandResult(String feedbackToUser, TabWindow tabWindow, boolean showHelp, boolean exit, boolean clearStaffs, boolean clearTransactions) {
+    public CommandResult(String feedbackToUser, TabWindow tabWindow, boolean showHelp, boolean exit, boolean clearResultDisplay) {
         this.feedbackToUser = requireNonNull(feedbackToUser);
         this.tabWindow = tabWindow;
         this.showHelp = showHelp;
         this.exit = exit;
-        this.clearStaffs = clearStaffs;
-        this.clearTransactions = clearTransactions;
+        this.clearResultDisplay = clearResultDisplay;
     }
 
     /**
@@ -54,7 +51,7 @@ public class CommandResult {
      * and other fields set to their default value.
      */
     public CommandResult(String feedbackToUser, TabWindow tabWindow) {
-        this(feedbackToUser, tabWindow, false, false, false, false);
+        this(feedbackToUser, tabWindow, false, false);
     }
 
     /**
@@ -62,7 +59,7 @@ public class CommandResult {
      * and other fields set to their default value.
      */
     public CommandResult(String feedbackToUser) {
-        this(feedbackToUser, TabWindow.CURRENT, false, false, false, false);
+        this(feedbackToUser, TabWindow.CURRENT, false, false);
     }
 
     public String getFeedbackToUser() {
@@ -81,13 +78,10 @@ public class CommandResult {
         return exit;
     }
 
-    public boolean isClearStaffs() {
-        return clearStaffs;
+    public boolean isClearResultDisplay() {
+        return clearResultDisplay;
     }
 
-    public boolean isClearTransactions() {
-        return clearTransactions;
-    }
 
     @Override
     public boolean equals(Object other) {

--- a/src/main/java/transact/logic/parser/AddressBookParser.java
+++ b/src/main/java/transact/logic/parser/AddressBookParser.java
@@ -10,6 +10,7 @@ import java.util.regex.Pattern;
 import transact.commons.core.LogsCenter;
 import transact.logic.commands.AddStaffCommand;
 import transact.logic.commands.AddTransactionCommand;
+import transact.logic.commands.ClearResultBoxCommand;
 import transact.logic.commands.ClearStaffCommand;
 import transact.logic.commands.ClearTransactionCommand;
 import transact.logic.commands.Command;
@@ -95,6 +96,8 @@ public class AddressBookParser {
         case ClearTransactionCommand.COMMAND_WORD:
             return new ClearTransactionCommand();
 
+        case ClearResultBoxCommand.COMMAND_WORD:
+            return new ClearResultBoxCommand();
         default:
             logger.finer("This user input caused a ParseException: " + userInput);
             throw new ParseException(MESSAGE_UNKNOWN_COMMAND);

--- a/src/main/java/transact/logic/parser/AddressBookParser.java
+++ b/src/main/java/transact/logic/parser/AddressBookParser.java
@@ -8,18 +8,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import transact.commons.core.LogsCenter;
-import transact.logic.commands.AddStaffCommand;
-import transact.logic.commands.AddTransactionCommand;
-import transact.logic.commands.ClearCommand;
-import transact.logic.commands.Command;
-import transact.logic.commands.DeleteStaffCommand;
-import transact.logic.commands.DeleteTransactionCommand;
-import transact.logic.commands.EditStaffCommand;
-import transact.logic.commands.EditTransactionCommand;
-import transact.logic.commands.ExitCommand;
-import transact.logic.commands.FindCommand;
-import transact.logic.commands.HelpCommand;
-import transact.logic.commands.ViewCommand;
+import transact.logic.commands.*;
 import transact.logic.parser.exceptions.ParseException;
 
 /**
@@ -76,8 +65,8 @@ public class AddressBookParser {
         case DeleteStaffCommand.COMMAND_WORD:
             return new DeleteStaffCommandParser().parse(arguments);
 
-        case ClearCommand.COMMAND_WORD:
-            return new ClearCommand();
+        case ClearStaffCommand.COMMAND_WORD:
+            return new ClearStaffCommand();
 
         case FindCommand.COMMAND_WORD:
             return new FindCommandParser().parse(arguments);
@@ -90,6 +79,9 @@ public class AddressBookParser {
 
         case HelpCommand.COMMAND_WORD:
             return new HelpCommand();
+
+        case ClearTransactionCommand.COMMAND_WORD:
+            return new ClearTransactionCommand();
 
         default:
             logger.finer("This user input caused a ParseException: " + userInput);

--- a/src/main/java/transact/logic/parser/AddressBookParser.java
+++ b/src/main/java/transact/logic/parser/AddressBookParser.java
@@ -8,7 +8,19 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import transact.commons.core.LogsCenter;
-import transact.logic.commands.*;
+import transact.logic.commands.AddStaffCommand;
+import transact.logic.commands.AddTransactionCommand;
+import transact.logic.commands.ClearStaffCommand;
+import transact.logic.commands.ClearTransactionCommand;
+import transact.logic.commands.Command;
+import transact.logic.commands.DeleteStaffCommand;
+import transact.logic.commands.DeleteTransactionCommand;
+import transact.logic.commands.EditStaffCommand;
+import transact.logic.commands.EditTransactionCommand;
+import transact.logic.commands.ExitCommand;
+import transact.logic.commands.FindCommand;
+import transact.logic.commands.HelpCommand;
+import transact.logic.commands.ViewCommand;
 import transact.logic.parser.exceptions.ParseException;
 
 /**

--- a/src/main/java/transact/ui/MainWindow.java
+++ b/src/main/java/transact/ui/MainWindow.java
@@ -174,6 +174,42 @@ public class MainWindow extends UiPart<Stage> {
         primaryStage.hide();
     }
 
+    /**
+     * Clear the Address Book.
+     */
+    @FXML
+    private void handleClearStaffs() throws CommandException, ParseException {
+        String commandText = "clearstaff";
+        try {
+            CommandResult commandResult = logic.execute(commandText);
+            logger.info("Result: " + commandResult.getFeedbackToUser());
+            resultDisplay.setFeedbackToUser(commandResult.getFeedbackToUser());
+            switchTab(commandResult.getTabWindow());
+        } catch (CommandException | ParseException e) {
+            logger.info("An error occurred while executing command: " + commandText);
+            resultDisplay.setFeedbackToUser(e.getMessage());
+            throw e;
+        }
+    }
+
+    /**
+     * Clear the Transaction Book.
+     */
+    @FXML
+    private void handleClearTransactions() throws CommandException, ParseException {
+        String commandText = "cleartransaction";
+        try {
+            CommandResult commandResult = logic.execute(commandText);
+            logger.info("Result: " + commandResult.getFeedbackToUser());
+            resultDisplay.setFeedbackToUser(commandResult.getFeedbackToUser());
+            switchTab(commandResult.getTabWindow());
+        } catch (CommandException | ParseException e) {
+            logger.info("An error occurred while executing command: " + commandText);
+            resultDisplay.setFeedbackToUser(e.getMessage());
+            throw e;
+        }
+    }
+
     public CardListPanel getCardListPanel() {
         return cardListPanel;
     }

--- a/src/main/java/transact/ui/MainWindow.java
+++ b/src/main/java/transact/ui/MainWindow.java
@@ -233,6 +233,10 @@ public class MainWindow extends UiPart<Stage> {
                 handleExit();
             }
 
+            if (commandResult.isClearResultDisplay()) {
+                resultDisplay.clear();
+            }
+
             switchTab(commandResult.getTabWindow());
 
             return commandResult;

--- a/src/main/java/transact/ui/ResultDisplay.java
+++ b/src/main/java/transact/ui/ResultDisplay.java
@@ -28,10 +28,10 @@ public class ResultDisplay extends UiPart<Region> {
             currentText += "\n"; // Add a newline to separate messages
         }
         resultDisplay.setText(currentText + feedbackToUser);
-        //resultDisplay.appendText(currentText + feedbackToUser);
-
-        // 将滚动条滚动到最底部
         resultDisplay.positionCaret(resultDisplay.getLength());
+    }
+    public void clear() {
+        resultDisplay.clear();
     }
 
 }

--- a/src/main/java/transact/ui/ResultDisplay.java
+++ b/src/main/java/transact/ui/ResultDisplay.java
@@ -16,13 +16,22 @@ public class ResultDisplay extends UiPart<Region> {
     @FXML
     private TextArea resultDisplay;
 
+
     public ResultDisplay() {
         super(FXML);
     }
 
     public void setFeedbackToUser(String feedbackToUser) {
         requireNonNull(feedbackToUser);
-        resultDisplay.setText(feedbackToUser);
+        String currentText = resultDisplay.getText();
+        if (!currentText.isEmpty()) {
+            currentText += "\n"; // Add a newline to separate messages
+        }
+        resultDisplay.setText(currentText + feedbackToUser);
+        //resultDisplay.appendText(currentText + feedbackToUser);
+
+        // 将滚动条滚动到最底部
+        resultDisplay.positionCaret(resultDisplay.getLength());
     }
 
 }

--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -25,6 +25,8 @@
            <MenuBar fx:id="menuBar" stylesheets="@DarkTheme.css" BorderPane.alignment="CENTER">
              <Menu mnemonicParsing="false" text="File">
                <MenuItem mnemonicParsing="false" onAction="#handleExit" text="Exit" />
+               <MenuItem mnemonicParsing="false" onAction="#handleClearStaffs" text="Clear Staffs" />
+               <MenuItem mnemonicParsing="false" onAction="#handleClearTransactions" text="Clear Transactions" />
              </Menu>
              <Menu mnemonicParsing="false" text="Help">
                <MenuItem fx:id="userGuideMenuItem" mnemonicParsing="false" onAction="#handleHelp" text="View user guide" />

--- a/src/test/java/transact/logic/commands/ClearStaffCommandTest.java
+++ b/src/test/java/transact/logic/commands/ClearStaffCommandTest.java
@@ -11,14 +11,14 @@ import transact.model.Model;
 import transact.model.ModelManager;
 import transact.model.UserPrefs;
 
-public class ClearCommandTest {
+public class ClearStaffCommandTest {
 
     @Test
     public void execute_emptyAddressBook_success() {
         Model model = new ModelManager();
         Model expectedModel = new ModelManager();
 
-        assertCommandSuccess(new ClearCommand(), model, ClearCommand.MESSAGE_SUCCESS, expectedModel);
+        assertCommandSuccess(new ClearStaffCommand(), model, ClearStaffCommand.MESSAGE_SUCCESS, expectedModel);
     }
 
     @Test
@@ -27,7 +27,7 @@ public class ClearCommandTest {
         Model expectedModel = new ModelManager(getTypicalAddressBook(), getTypicalTransactionBook(), new UserPrefs());
         expectedModel.setAddressBook(new AddressBook());
 
-        assertCommandSuccess(new ClearCommand(), model, ClearCommand.MESSAGE_SUCCESS, expectedModel);
+        assertCommandSuccess(new ClearStaffCommand(), model, ClearStaffCommand.MESSAGE_SUCCESS, expectedModel);
     }
 
 }

--- a/src/test/java/transact/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/transact/logic/parser/AddressBookParserTest.java
@@ -14,7 +14,7 @@ import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
 
 import transact.logic.commands.AddStaffCommand;
-import transact.logic.commands.ClearCommand;
+import transact.logic.commands.ClearStaffCommand;
 import transact.logic.commands.DeleteStaffCommand;
 import transact.logic.commands.EditStaffCommand;
 import transact.logic.commands.EditStaffCommand.EditPersonDescriptor;
@@ -42,8 +42,8 @@ public class AddressBookParserTest {
 
     @Test
     public void parseCommand_clear() throws Exception {
-        assertTrue(parser.parseCommand(ClearCommand.COMMAND_WORD) instanceof ClearCommand);
-        assertTrue(parser.parseCommand(ClearCommand.COMMAND_WORD + " 3") instanceof ClearCommand);
+        assertTrue(parser.parseCommand(ClearStaffCommand.COMMAND_WORD) instanceof ClearStaffCommand);
+        assertTrue(parser.parseCommand(ClearStaffCommand.COMMAND_WORD + " 3") instanceof ClearStaffCommand);
     }
 
     @Test


### PR DESCRIPTION
The clear command is done so the result display box can be clear any time. The pull request also involves the scroll implementation in the result box and the change involves button of "clear staff" and "clear transaction" to quickly reset the addressbook and transaction book. #58 is resolved